### PR TITLE
Remove nose functions

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -10,14 +10,11 @@ source:
 
 requirements:
   build:
-    - setuptools
     - python
-    - pyyaml
-    - six
+    - pip
   run:
     - python
     - pyyaml
-    - nose
     - six
 
 test:
@@ -26,12 +23,17 @@ test:
   requires:
     - pytest
   commands:
+    - snbuild --help
+    - sndump --help
+    - snscrape --help
+    - snsql --help
+    - snvalidate --help
     - pytest --pyargs standard_names --doctest-modules -o doctest_optionflags="NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE"
 
-
 build:
+  noarch: python
   number: 0
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
 about:
   home: https://github.com/csdms/standard_names

--- a/standard_names/__init__.py
+++ b/standard_names/__init__.py
@@ -5,14 +5,6 @@ from .registry import NamesRegistry
 from .error import BadNameError, BadRegistryError
 
 
-__version__ = "0.2.2"
-
-
-def check():
-    from nose.core import run
-
-    run("standard_names")
-
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/standard_names/tests/test_io.py
+++ b/standard_names/tests/test_io.py
@@ -2,8 +2,6 @@
 """Unit tests for standard_names.io module."""
 from six.moves import StringIO
 
-from nose.tools import assert_equal, assert_in
-
 from standard_names import StandardName, BadNameError
 from standard_names.utilities import from_model_file
 
@@ -54,19 +52,19 @@ def test_from_model_file():
     """Read from a YAML model file that contains one model."""
     names = from_model_file(_SINGLE_MODEL_FILE_STREAM)
 
-    assert_in("air__density", names)
-    assert_in("air__emissivity", names)
-    assert_equal(len(names), 2)
+    assert "air__density" in names
+    assert "air__emissivity" in names
+    assert len(names) == 2
 
 
 def test_from_multiple_model_file():
     """Read from a YAML model file that contains multiple models."""
     names = from_model_file(_MULTIPLE_MODEL_FILE_STREAM)
 
-    assert_in("air__density", names)
-    assert_in("air__emissivity", names)
-    assert_in("water__temperature", names)
-    assert_equal(len(names), 3)
+    assert "air__density" in names
+    assert "air__emissivity" in names
+    assert "water__temperature" in names
+    assert len(names) == 3
 
 
 def test_from_model_file_with_intent():
@@ -76,6 +74,6 @@ def test_from_model_file_with_intent():
     """
     names = from_model_file(_SINGLE_MODEL_FILE_STREAM_WITH_INTENT)
 
-    assert_in("air__density", names)
-    assert_in("air__emissivity", names)
-    assert_equal(len(names), 2)
+    assert "air__density" in names
+    assert "air__emissivity" in names
+    assert len(names) == 2

--- a/standard_names/tests/test_namesregistry.py
+++ b/standard_names/tests/test_namesregistry.py
@@ -1,16 +1,6 @@
 #!/usr/bin/env python
 """Unit tests for standard_names.NamesRegistry."""
-from nose.tools import (
-    assert_greater,
-    assert_equal,
-    assert_raises,
-    assert_in,
-    assert_is_instance,
-    assert_tuple_equal,
-    assert_list_equal,
-    assert_set_equal,
-    assert_raises_regexp,
-)
+import pytest
 from six import string_types
 from six.moves import StringIO
 
@@ -19,43 +9,43 @@ from standard_names.registry import load_names_from_txt
 
 
 def test_load_names_bad_onerror():
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         load_names_from_txt("dummy_arg", onerror="bad_value")
 
 
 def test_load_names_bad_name_pass():
     file_like = StringIO("air__temperature\nwater_temperature")
     names = load_names_from_txt(file_like, onerror="pass")
-    assert_set_equal(names, {"air__temperature"})
+    assert names == {"air__temperature"}
 
 
 def test_load_names_bad_name_raise():
     file_like = StringIO("air__temperature\nwater_temperature")
-    with assert_raises_regexp(BadRegistryError, "Registry contains invalid names"):
+    with pytest.raises(BadRegistryError, match="Registry contains invalid names"):
         load_names_from_txt(file_like, onerror="raise")
 
     file_like = StringIO("air__temperature\nwater_temperature")
     try:
         load_names_from_txt(file_like, onerror="raise")
     except BadRegistryError as error:
-        assert_tuple_equal(error.names, ("water_temperature",))
+        assert error.names == ("water_temperature",)
 
 
 def test_create_full():
     """Test creating default registry."""
     nreg = NamesRegistry()
-    assert_greater(len(nreg), 0)
+    assert len(nreg) > 0
 
 
 def test_create_empty():
     """Test creating default registry."""
     nreg = NamesRegistry(None)
-    assert_equal(len(nreg), 0)
+    assert len(nreg) == 0
 
 
 def test_create_with_too_many_args():
     """Test creating a registry with too many arguments."""
-    with assert_raises(ValueError):
+    with pytest.raises(ValueError):
         NamesRegistry("file1", "file2")
 
 
@@ -63,26 +53,26 @@ def test_create_with_file_like():
     """Test creating a registry from a file_like object."""
     file_like = StringIO("air__temperature")
     names = NamesRegistry(file_like)
-    assert_tuple_equal(names.names, ("air__temperature",))
+    assert names.names == ("air__temperature",)
 
     file_like = StringIO("air__temperature")
     another_file_like = StringIO("water__temperature")
     names = NamesRegistry([file_like, another_file_like])
-    assert_is_instance(names.names, tuple)
-    assert_list_equal(sorted(names.names), ["air__temperature", "water__temperature"])
+    assert isinstance(names.names, tuple)
+    assert sorted(names.names) == ["air__temperature", "water__temperature"]
 
 
 def test_create_with_from_path():
     """Test creating registry with from_path."""
     file_like = StringIO("air__temperature")
     names = NamesRegistry.from_path(file_like)
-    assert_tuple_equal(names.names, ("air__temperature",))
+    assert names.names == ("air__temperature",)
 
 
 def test_bad_name():
     """Try to add an invalid name."""
     nreg = NamesRegistry(None)
-    with assert_raises(BadNameError):
+    with pytest.raises(BadNameError):
         nreg.add("air_temperature")
 
 
@@ -91,12 +81,12 @@ def test_add_string():
     nreg = NamesRegistry(None)
     nreg.add("air__temperature")
 
-    assert_in(StandardName("air__temperature"), nreg)
-    assert_in("air__temperature", nreg)
-    assert_equal(len(nreg), 1)
+    assert StandardName("air__temperature") in nreg
+    assert "air__temperature" in nreg
+    assert len(nreg) == 1
 
     nreg.add("air__temperature")
-    assert_equal(len(nreg), 1)
+    assert len(nreg) == 1
 
 
 def test_collection_contains_names():
@@ -106,7 +96,7 @@ def test_collection_contains_names():
     nreg.add("water__temperature")
 
     for name in nreg:
-        assert_is_instance(name, string_types)
+        assert isinstance(name, string_types)
 
 
 def test_add_name():
@@ -114,8 +104,8 @@ def test_add_name():
     nreg = NamesRegistry(None)
     nreg.add(StandardName("air__temperature"))
 
-    assert_in(StandardName("air__temperature"), nreg)
-    assert_in("air__temperature", nreg)
+    assert StandardName("air__temperature") in nreg
+    assert "air__temperature" in nreg
 
 
 def test_unique_names():
@@ -124,10 +114,10 @@ def test_unique_names():
     nreg.add("air__temperature")
     nreg.add("water__temperature")
 
-    assert_equal(len(nreg), 2)
+    assert len(nreg) == 2
 
-    assert_in("air__temperature", nreg)
-    assert_in("water__temperature", nreg)
+    assert "air__temperature" in nreg
+    assert "water__temperature" in nreg
 
 
 def test_unique_objects():
@@ -138,9 +128,9 @@ def test_unique_objects():
 
     objs = nreg.objects
 
-    assert_equal(len(objs), 2)
-    assert_in("air", objs)
-    assert_in("water", objs)
+    assert len(objs) == 2
+    assert "air" in objs
+    assert "water" in objs
 
 
 def test_unique_quantities():
@@ -151,7 +141,7 @@ def test_unique_quantities():
 
     quantities = nreg.quantities
 
-    assert_tuple_equal(quantities, ("temperature",))
+    assert quantities == ("temperature",)
 
 
 def test_unique_operators():
@@ -164,6 +154,6 @@ def test_unique_operators():
 
     operators = nreg.operators
 
-    assert_equal(len(operators), 2)
-    assert_in("log", operators)
-    assert_in("mean", operators)
+    assert len(operators) == 2
+    assert "log" in operators
+    assert "mean" in operators

--- a/standard_names/tests/test_standardname.py
+++ b/standard_names/tests/test_standardname.py
@@ -1,18 +1,6 @@
 #!/usr/bin/env python
 """Unit tests for standard_names.StandardName"""
-
-from nose.tools import (
-    assert_greater,
-    assert_less,
-    assert_equal,
-    assert_not_equal,
-    assert_in,
-    assert_not_in,
-    assert_is_instance,
-    assert_tuple_equal,
-    assert_raises,
-    assert_false,
-)
+import pytest
 
 from standard_names import StandardName, BadNameError
 
@@ -21,82 +9,82 @@ def test_create():
     """Test class creation."""
     name = StandardName("air__temperature")
 
-    assert_equal(name.name, "air__temperature")
+    assert name.name == "air__temperature"
 
 
 def test_bad_name():
     """Try to create an invalid name."""
-    with assert_raises(BadNameError):
+    with pytest.raises(BadNameError):
         StandardName("air_temperature")
 
-    with assert_raises(BadNameError):
+    with pytest.raises(BadNameError):
         StandardName("air___temperature")
 
-    with assert_raises(BadNameError):
+    with pytest.raises(BadNameError):
         StandardName("Air__Temperature")
 
-    with assert_raises(BadNameError):
+    with pytest.raises(BadNameError):
         StandardName("_air__temperature")
 
-    with assert_raises(BadNameError):
+    with pytest.raises(BadNameError):
         StandardName("air__temperature_")
 
-    with assert_raises(BadNameError):
+    with pytest.raises(BadNameError):
         StandardName("air__temperature__0")
 
-    with assert_raises(BadNameError):
+    with pytest.raises(BadNameError):
         StandardName("0_air__temperature")
 
 
 def test_get_object():
     """Retrieve an object from a standard name."""
     name = StandardName("air__temperature")
-    assert_equal(name.object, "air")
+    assert name.object == "air"
 
 
 def test_get_quantity():
     """Retrieve a quantity from a standard name."""
     name = StandardName("air__temperature")
-    assert_equal(name.quantity, "temperature")
+    assert name.quantity == "temperature"
 
 
 def test_get_empty_operator():
     """Retrieve an operator from a standard name."""
     name = StandardName("air__temperature")
 
-    assert_tuple_equal(name.operators, ())
+    assert name.operators == ()
 
 
 def test_get_one_operator():
     """Retrieve an operator from a standard name."""
     name = StandardName("air__log_of_temperature")
 
-    assert_tuple_equal(name.operators, ("log",))
+    assert name.operators == ("log",)
 
 
 def test_get_multiple_operators():
     """Retrieve an operator from a standard name."""
     name = StandardName("air__mean_of_log_of_temperature")
-    assert_tuple_equal(name.operators, ("mean", "log"))
+    assert name.operators == ("mean", "log")
 
 
 def test_compare_names():
     """Compare a names."""
     name = StandardName("air__temperature")
 
-    assert_equal(name, StandardName("air__temperature"))
-    assert_not_equal(name, StandardName("water__temperature"))
+    assert name == StandardName("air__temperature")
+    assert name != StandardName("water__temperature")
 
 
 def test_compare_name_to_str():
     """Compare a name to a string."""
     name = StandardName("air__temperature")
 
-    assert_equal(name, "air__temperature")
-    assert_not_equal(name, "water__temperature")
+    assert name == "air__temperature"
+    assert name != "water__temperature"
 
-    assert_false(name != "air__temperature")
-    assert_false(name == "water__temperature")
+    assert not (name != "air__temperature")
+    assert not (name == "water__temperature")
 
 
 def test_lt_name_to_str():
@@ -104,10 +92,10 @@ def test_lt_name_to_str():
     air = StandardName("air__temperature")
     water = StandardName("water__temperature")
 
-    assert_less(air, "water__temperature")
-    assert_less(air, water)
-    assert_false("water__temperature" < air)
-    assert_false(water < air)
+    assert air < "water__temperature"
+    assert air < water
+    assert not ("water__temperature" < air)
+    assert not (water < air)
 
 
 def test_gt_name_to_str():
@@ -115,10 +103,10 @@ def test_gt_name_to_str():
     air = StandardName("air__temperature")
     water = StandardName("water__temperature")
 
-    assert_false(air > "water__temperature")
-    assert_false(air > water)
-    assert_greater("water__temperature", air)
-    assert_greater(water, air)
+    assert not (air > "water__temperature")
+    assert not (air > water)
+    assert "water__temperature" > air
+    assert water > air
 
 
 def test_hash():
@@ -128,14 +116,14 @@ def test_hash():
     a_bunch_of_names.add(StandardName("air__temperature"))
     a_bunch_of_names.add(StandardName("water__temperature"))
 
-    assert_equal(len(a_bunch_of_names), 2)
+    assert len(a_bunch_of_names) == 2
 
     a_bunch_of_names.add(StandardName("air__temperature"))
 
-    assert_equal(len(a_bunch_of_names), 2)
+    assert len(a_bunch_of_names) == 2
 
-    assert_in("air__temperature", a_bunch_of_names)
-    assert_in("water__temperature", a_bunch_of_names)
-    assert_in(StandardName("air__temperature"), a_bunch_of_names)
+    assert "air__temperature" in a_bunch_of_names
+    assert "water__temperature" in a_bunch_of_names
+    assert StandardName("air__temperature") in a_bunch_of_names
 
-    assert_not_in("surface__temperature", a_bunch_of_names)
+    assert "surface__temperature" not in a_bunch_of_names


### PR DESCRIPTION
This pull request removes all references to `nose` and, in particular, the `assert_*` functions. We now use `pytest` for testing.