### PR TITLE
Added missing dependency to six library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author="Eric Hutton",
     author_email="eric.hutton@colorado.edu",
     url="https://csdms.colorado.edu",
-    install_requires=["pyyaml"],
+    install_requires=["pyyaml", "six"],
     packages=[
         "standard_names",
         "standard_names.cmd",


### PR DESCRIPTION
Tried installing in an empty system but got an error about the six package not being found

```bash
docker run -it --rm -v $PWD:/code python:3.7 bash
```

```bash
cd /code
python setup.py install
```

```bash
root@78d3d4ad2be5:/# python
Python 3.7.1 (default, Nov 16 2018, 22:26:09) 
[GCC 6.3.0 20170516] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import standard_names
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.7/site-packages/standard_names-0.2.4-py3.7.egg/standard_names/__init__.py", line 3, in <module>
    from .standardname import StandardName, is_valid_name
  File "/usr/local/lib/python3.7/site-packages/standard_names-0.2.4-py3.7.egg/standard_names/standardname.py", line 5, in <module>
    from six import string_types
ModuleNotFoundError: No module named 'six'
```

so I added `six` to setup.py