### PR TITLE
Fixes for Python 3.12

### DIFF
--- a/standard_names/__init__.py
+++ b/standard_names/__init__.py
@@ -1,10 +1,10 @@
 """The CSDMS Standard Names"""
-import pkg_resources
+from importlib.metadata import version
 from .error import BadNameError, BadRegistryError
 from .registry import NamesRegistry
 from .standardname import StandardName, is_valid_name
 
-__version__ = pkg_resources.get_distribution("standard-names").version
+__version__ = version("standard-names")
 __all__ = [
     "StandardName",
     "is_valid_name",

--- a/standard_names/registry.py
+++ b/standard_names/registry.py
@@ -63,11 +63,11 @@ def load_names_from_txt(file_like, onerror="raise"):
 
 
 def _strict_version_or_raise(version_str):
-    from distutils.version import StrictVersion
+    from packaging.version import Version, InvalidVersion
 
-    if StrictVersion.version_re.match(version_str):
-        return StrictVersion(version_str)
-    else:
+    try:
+        return Version(version_str)
+    except InvalidVersion:
         raise ValueError("{version}: Not a version string".format(version=version_str))
 
 

--- a/standard_names/utilities/io.py
+++ b/standard_names/utilities/io.py
@@ -170,7 +170,7 @@ def from_model_file(stream):
     """
     import yaml
 
-    models = yaml.load_all(stream)
+    models = yaml.safe_load_all(stream)
     names = _find_unique_names(models)
     return names
 


### PR DESCRIPTION
This PR bundles a set of minor fixes to get *standard_names* working in Python 3.12. See especially the commit message in 0ec97f009865b29cca62a6a59e10b8ba357d9e0a.

Thia fixes #8 and fixes #10.